### PR TITLE
Remove overview from URLs

### DIFF
--- a/kumascript/macros/EPUBRef.ejs
+++ b/kumascript/macros/EPUBRef.ejs
@@ -43,14 +43,13 @@ const text = mdn.localStringMap({
 <section id="Quick_links">
   <ol>
     <li><a href="<%=baseURL%>"><%=text['EPUB']%></a></li>
-    <li><a href="<%=baseURL%>Overview"><%=text['Overview']%></a></li>
     <li><a href="<%=baseURL%>Relationship_to_the_web"><%=text['Relationship_to_the_web']%></a></li>
     <li><strong><%=text['Reference']%></strong></li>
     <li class="toggle">
       <details open>
         <summary><%=text['Structure']%></summary>
         <ol>
-          <li><a href="<%=baseURL%>Structure/Overview"><%=text['Structure_overview']%></a></li>
+          <li><a href="<%=baseURL%>Structure/"><%=text['Structure_overview']%></a></li>
           <li><a href="<%=baseURL%>Structure/OCF"><%=text['Open_container_format']%></a></li>
           <li><a href="<%=baseURL%>Structure/Mimetype"><%=text['Mimetype_file']%></a></li>
           <li><a href="<%=baseURL%>Structure/META-INF"><%=text['META-INF_directory']%></a></li>
@@ -62,7 +61,7 @@ const text = mdn.localStringMap({
       <details open>
         <summary><%=text['Package_file']%></summary>
         <ol>
-          <li><a href="<%=baseURL%>Package/Overview"><%=text['Package_file_overview']%></a></li>
+          <li><a href="<%=baseURL%>Package/"><%=text['Package_file_overview']%></a></li>
           <li><a href="<%=baseURL%>Package/Metadata"><%=text['Metadata']%></a></li>
           <li><a href="<%=baseURL%>Package/Manifest"><%=text['Manifest']%></a></li>
           <li><a href="<%=baseURL%>Package/Spine"><%=text['Spine']%></a></li>
@@ -73,7 +72,7 @@ const text = mdn.localStringMap({
       <details open>
         <summary><%=text['Navigation']%></summary>
         <ol>
-          <li><a href="<%=baseURL%>Navigation/Overview"><%=text['Navigation_overview']%></a></li>
+          <li><a href="<%=baseURL%>Navigation/"><%=text['Navigation_overview']%></a></li>
           <li><a href="<%=baseURL%>Navigation/TOC"><%=text['TOC']%></a></li>
           <li><a href="<%=baseURL%>Navigation/Landmarks"><%=text['Landmarks']%></a></li>
           <li><a href="<%=baseURL%>Navigation/Page-list"><%=text['Page_list']%></a></li>
@@ -84,7 +83,7 @@ const text = mdn.localStringMap({
       <details open>
         <summary><%=text['Publication_content']%></summary>
         <ol>
-          <li><a href="<%=baseURL%>Content/Overview"><%=text['Publication_content_overview']%></a></li>
+          <li><a href="<%=baseURL%>Content/"><%=text['Publication_content_overview']%></a></li>
           <li><a href="<%=baseURL%>Content/XHTML"><%=text['XHTML']%></a></li>
           <li><a href="<%=baseURL%>Content/SVG"><%=text['SVG']%></a></li>
           <li><a href="<%=baseURL%>Content/CSS"><%=text['CSS']%></a></li>


### PR DESCRIPTION
To better match MDN's directory structure let's make these index files instead of overview files.